### PR TITLE
Add inference metadata [WIP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ these models for the following types of use-cases:
 
 | Role Name                | Description |
 | ------------------------ | ----------- |
-| ml-model:inference-image | Represents a containerized version of the model that can be used to generate inferences. See the [Inferencing Images](#inferencing-images) section below for details on related fields. |
+| ml-model:inferencing-image | Represents a containerized version of the model that can be used to generate inferences. See the [Inferencing Images](#inferencing-images) section below for details on related fields. |
 
 ### Inferencing Images
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,31 @@ these models for the following types of use-cases:
 | ml-model:prediction_type   | string                    | **REQUIRED.** The type of prediction that the model makes. It is STRONGLY RECOMMENDED that you use one of the values described below, but other values are allowed.   |
 | ml-model:architecture      | string                    | **REQUIRED.** Identifies the architecture employed by the model (e.g. RCNN, U-Net, etc.). This may be any string identifier, but publishers are encouraged to use well-known identifiers whenever possible. |
 
+## Asset Objects
+
+### Roles
+
+| Role Name                | Description |
+| ------------------------ | ----------- |
+| ml-model:inference-image | Represents a containerized version of the model that can be used to generate inferences. See the [Inferencing Images](#inferencing-images) section below for details on related fields. |
+
+### Inferencing Images
+
+Assets with the `ml-model:inferencing-image` role represent image that can be run to generate inferences using this model. The `href`
+field for these assets should be a fully Docker URI for the image, including the repository, username, image, and tag. The following fields are
+defined for these assets:
+
+| Field Name                 | Type          | Description |
+| -------------------------- | ------------- | ----------- |
+| ml-model:command           | string        | **REQUIRED.** A string that should be used as the `COMMAND` argument to the [`docker run`](https://docs.docker.com/engine/reference/run/) command. |
+| ml-model:input-volume      | string        | **REQUIRED.** The volume in the Docker container to which the local directory containing input data should be mapped. For instance, a value of `"/app/data/in"` means that the user should include the `-v /local/dir/with/input-data:/app/data/in` option in the [`docker run`](https://docs.docker.com/engine/reference/run/) command. |
+| ml-model:output-volume     | string\|null  | **REQUIRED.** The volume in the Docker container to which a local directory should be mapped to store output inferences. For instance, a value of `"/app/data/out"` means that the user should include the `-v /local/dir/with/input-data:/app/data/out` option in the [`docker run`](https://docs.docker.com/engine/reference/run/) command. If `null`, then it is assumed that output data will be written to the input volume from `ml-model:input-volume`. |
+| ml-model:requires-gpu      | boolean       | **REQUIRED.** Whether GPU is required to run this image. |
+| ml-model:command-options   | string        | A string representing any additional options that should be appended to the [`docker run`](https://docs.docker.com/engine/reference/run/) command. |
+
+It is RECOMMENDED that model publishers use the Asset `description` field to describe any other requirements or constraints for running the model
+container.
+
 ### Additional Field Information
 
 #### ml-model:learning_approach
@@ -107,15 +132,6 @@ It is RECOMMENDED that following STAC Extensions be used in conjunction with the
 
 - [Scientific Citation Extension](https://github.com/stac-extensions/scientific): This extension should be used to describe how the model should
   cited in publications, as well as to reference any existing publications associated with the model.
-
-## Relation types
-
-The following types should be used as applicable `rel` types in the
-[Link Object](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#link-object).
-
-| Type                | Description |
-| ------------------- | ----------- |
-| TBD                 | More detail to come... |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -65,14 +65,17 @@ these models for the following types of use-cases:
 
 | Role Name                | Description |
 | ------------------------ | ----------- |
-| ml-model:inference-runtime | Represents a containerized version of the model that can be used to generate inferences. See the [Inferencing Runtimes](#inferencing-runtimes) section below for details on related fields. |
+| ml-model:inference-runtime | Represents a file containing instructions for running a containerized version of the model to generate inferences. See the [Inference Runtimes](#inference-runtimes) section below for details on related fields. |
 
-### Inferencing Runtimes
+### Inference Runtimes
 
-An Asset with the `ml-model:inference-runtime` role represents a
-[Compose file](https://github.com/compose-spec/compose-spec/blob/master/spec.md#compose-file) that can be used to run a containerized version of the
-model to generate inferences. Compose files must be in YAML format, which currently has no official IANA media type. It is RECOMMENDED that you use
-`text/x-yaml` for the `type` field in these Assets.
+An Asset with the `ml-model:inference-runtime` role represents a file containing instructions for running a containerized version of the model to
+generate inferences. Currently, only [Compose files](https://github.com/compose-spec/compose-spec/blob/master/spec.md#compose-file) are supported,
+but support is planned for other formats, including [Common Workflow Language (CWL)](https://www.commonwl.org/) and [Workflow Description Language
+(WDL)](https://openwdl.org/).
+
+The `"type"` field should be used to indicate the format of this asset. Assets in the Compose format should have a `"type"` value of
+`"text/x-yaml; application=compose"`.
 
 While the Compose file defines nearly all of the parameters required to run the containerized model image, we still need a way to define which host
 directory containing input data should be mounted to the container and to which host directory the output predictions should be written. The Compose
@@ -137,7 +140,7 @@ The following types should be used as applicable `rel` types in the
 
 | Type                         | Description |
 | ---------------------------- | ----------- |
-| ml-model:image               | Links with this relation type refer to Docker images built using the model. The `href` value for links of this type should contain a fully-qualified URI for the image as would be required for a command like `docker pull`. These URIs should be of the form `<registry_domain>/<user_or_organization_name>/<image_name>:<tag>`. Note that this image may or may not be the same as the image referred to in the Compose file in a [Inferencing Runtime Asset](#inferencing-runtimes) for this Item. |
+| ml-model:image               | Links with this relation type refer to Docker images built using the model. The `href` value for links of this type should contain a fully-qualified URI for the image as would be required for a command like `docker pull`. These URIs should be of the form `<registry_domain>/<user_or_organization_name>/<image_name>:<tag>`. Links with this relation type should have a `"type"` value of `"docker-image"` to indicate a Docker image. |
 
 ## Interpretation of STAC Fields
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ for a given [Learning Approach](#ml-modellearning_approach).
 - `"segmentation"`
 - `"regression"`
 
+## Relation types
+
+The following types should be used as applicable `rel` types in the
+[Link Object](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#link-object).
+
+| Type                         | Description |
+| ---------------------------- | ----------- |
+| ml-model:image               | Links with this relation type refer to Docker images built using the model. The `href` value for links of this type should contain a fully-qualified URI for the image as would be required for a command like `docker pull`. These URIs should be of the form `<registry_domain>/<user_or_organization_name>/<image_name>:<tag>`. Note that this image may or may not be the same as the image referred to in the Compose file in a [Inferencing Runtime Asset](#inferencing-runtimes) for this Item. |
+
 ## Interpretation of STAC Fields
 
 The semantics of ML model metadata can sometimes differ significantly from the use-cases for which STAC was originally intended (Earth observation

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ these models for the following types of use-cases:
 
 | Role Name                | Description |
 | ------------------------ | ----------- |
-| ml-model:inference-runtime | Represents a containerized version of the model that can be used to generate inferences. See the [Inferencing Images](#inferencing-images) section below for details on related fields. |
+| ml-model:inference-runtime | Represents a containerized version of the model that can be used to generate inferences. See the [Inferencing Runtimes](#inferencing-runtimes) section below for details on related fields. |
 
-### Inferencing Images
+### Inferencing Runtimes
 
 An Asset with the `ml-model:inference-runtime` role represents a
 [Compose file](https://github.com/compose-spec/compose-spec/blob/master/spec.md#compose-file) that can be used to run a containerized version of the

--- a/examples/dummy/inferencing.yml
+++ b/examples/dummy/inferencing.yml
@@ -1,0 +1,8 @@
+services:
+  model-inference:
+    image: docker.io/someusername/some_model_image:1
+    volumes:
+      - "${INPUT_VOLUME}:/var/data/input"
+      - "${OUTPUT_VOLUME}:/var/data/output"
+    entrypoint: bash /app/scripts/run-model.sh
+

--- a/examples/dummy/item.json
+++ b/examples/dummy/item.json
@@ -78,16 +78,12 @@
   ],
   "assets": {
     "model": {
-      "href": "gchr.io/username/model-repo:v1.0",
+      "href": "./inferencing.yml",
       "type": "application/vnd.oci.image.index.v1+json",
       "title": "Model image (v1.0)",
       "roles": [
-        "ml-model:inferencing-image"
-      ],
-      "ml-model:command": "/app/run-model.sh",
-      "ml-model:input-volume": "/var/data/input",
-      "ml-model:output-volume": "/var/data/output",
-      "ml-model:requires-gpu": false
+        "ml-model:inference-runtime"
+      ]
     },
     "other": {
       "href": "https://some-domain.com/another/thing.json",

--- a/examples/dummy/item.json
+++ b/examples/dummy/item.json
@@ -78,12 +78,21 @@
   ],
   "assets": {
     "model": {
-      "href": "https://github.com/m-mohr/gmlmc-hackathon-tree-detection/blob/main/epoch_019.ckpt",
-      "type": "application/x.ckpt",
-      "title": "Model checkpoint file",
+      "href": "gchr.io/username/model-repo:v1.0",
+      "type": "application/vnd.oci.image.index.v1+json",
+      "title": "Model image (v1.0)",
       "roles": [
-        "model"
-      ]
+        "ml-model:inferencing-image"
+      ],
+      "ml-model:command": "/app/run-model.sh",
+      "ml-model:input-volume": "/var/data/input",
+      "ml-model:output-volume": "/var/data/output",
+      "ml-model:requires-gpu": false
+    },
+    "other": {
+      "href": "https://some-domain.com/another/thing.json",
+      "type": "application/json",
+      "title": "Some other asset"
     }
   }
 }

--- a/examples/dummy/item.json
+++ b/examples/dummy/item.json
@@ -4,7 +4,7 @@
     "https://stac-extensions.github.io/ml-model/v1.0.0/schema.json"
   ],
   "type": "Feature",
-  "id": "item",
+  "id": "model-item",
   "bbox": [
     34.18,
     0.47,
@@ -74,13 +74,19 @@
       "href": "./collection.json",
       "type": "application/json",
       "title": "Containing Collection"
+    },
+    {
+      "rel": "ml-model:image",
+      "href": "registry.hub.docker.com/my-user/my-model:v1",
+      "type": "docker-image",
+      "title": "My Model (v1)"
     }
   ],
   "assets": {
     "model": {
       "href": "./inferencing.yml",
-      "type": "application/vnd.oci.image.index.v1+json",
-      "title": "Model image (v1.0)",
+      "type": "text/x-yaml; application=compose",
+      "title": "Model inferencing runtime",
       "roles": [
         "ml-model:inference-runtime"
       ]

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -32,7 +32,7 @@
                   ]
                 },
                 {
-                  "$ref": "#/definitions/item_fields"
+                  "$ref": "#/definitions/common_fields"
                 }
               ]
             },
@@ -40,7 +40,7 @@
               "$comment": "This validates the fields in Item Assets, but does not require them.",
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/definitions/asset_fields"
+                "$ref": "#/definitions/common_fields"
               }
             }
           }
@@ -82,7 +82,7 @@
                         "$ref": "#/definitions/require_any_field"
                       },
                       {
-                        "$ref": "#/definitions/asset_fields"
+                        "$ref": "#/definitions/common_fields"
                       }
                     ]
                   }
@@ -107,7 +107,7 @@
                         "$ref": "#/definitions/require_any_field"
                       },
                       {
-                        "$ref": "#/definitions/asset_fields"
+                        "$ref": "#/definitions/common_fields"
                       }
                     ]
                   }
@@ -165,7 +165,7 @@
         }
       ]
     },
-    "item_fields": {
+    "common_fields": {
       "$comment": "Add your new Item fields here. Don't require them here, do that above in the corresponding schema.",
       "type": "object",
       "properties": {
@@ -179,53 +179,6 @@
           "type": "string"
         }
       },
-      "patternProperties": {
-        "^(?!ml-model:)": {}
-      },
-      "additionalProperties": false
-    },
-    "asset_fields": {
-      "$comment": "Add your new Asset fields here. Don't require them here, do that above in the corresponding schema.",
-      "type": "object",
-      "if": {
-        "properties": {
-          "roles": {
-            "type": "array",
-            "contains": {
-              "const": "ml-model:inferencing-image"
-            }
-          }
-        },
-        "required": ["roles"]
-      },
-      "then": {"$ref": "#/definitions/inferencing-image-asset"},
-      "else": {
-        "patternProperties": {
-          "^(?!ml-model:)": {}
-        },
-        "additionalProperties": false
-      }
-    },
-    "inferencing-image-asset": {
-      "properties": {
-        "ml-model:command": {
-          "type": "string"
-        },
-        "ml-model:input-volume": {
-          "type": "string"
-        },
-        "ml-model:output-volume": {
-          "type": ["string", "null"]
-        },
-        "ml-model:requires-gpu": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "ml-model:command",
-        "ml-model:input-volume",
-        "ml-model:output-volume"
-      ],
       "patternProperties": {
         "^(?!ml-model:)": {}
       },

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -32,7 +32,7 @@
                   ]
                 },
                 {
-                  "$ref": "#/definitions/fields"
+                  "$ref": "#/definitions/item_fields"
                 }
               ]
             },
@@ -40,7 +40,7 @@
               "$comment": "This validates the fields in Item Assets, but does not require them.",
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/definitions/fields"
+                "$ref": "#/definitions/asset_fields"
               }
             }
           }
@@ -82,7 +82,7 @@
                         "$ref": "#/definitions/require_any_field"
                       },
                       {
-                        "$ref": "#/definitions/fields"
+                        "$ref": "#/definitions/asset_fields"
                       }
                     ]
                   }
@@ -107,7 +107,7 @@
                         "$ref": "#/definitions/require_any_field"
                       },
                       {
-                        "$ref": "#/definitions/fields"
+                        "$ref": "#/definitions/asset_fields"
                       }
                     ]
                   }
@@ -165,8 +165,8 @@
         }
       ]
     },
-    "fields": {
-      "$comment": "Add your new fields here. Don't require them here, do that above in the corresponding schema.",
+    "item_fields": {
+      "$comment": "Add your new Item fields here. Don't require them here, do that above in the corresponding schema.",
       "type": "object",
       "properties": {
         "ml-model:learning_approach": {
@@ -179,6 +179,53 @@
           "type": "string"
         }
       },
+      "patternProperties": {
+        "^(?!ml-model:)": {}
+      },
+      "additionalProperties": false
+    },
+    "asset_fields": {
+      "$comment": "Add your new Asset fields here. Don't require them here, do that above in the corresponding schema.",
+      "type": "object",
+      "if": {
+        "properties": {
+          "roles": {
+            "type": "array",
+            "contains": {
+              "const": "ml-model:inferencing-image"
+            }
+          }
+        },
+        "required": ["roles"]
+      },
+      "then": {"$ref": "#/definitions/inferencing-image-asset"},
+      "else": {
+        "patternProperties": {
+          "^(?!ml-model:)": {}
+        },
+        "additionalProperties": false
+      }
+    },
+    "inferencing-image-asset": {
+      "properties": {
+        "ml-model:command": {
+          "type": "string"
+        },
+        "ml-model:input-volume": {
+          "type": "string"
+        },
+        "ml-model:output-volume": {
+          "type": ["string", "null"]
+        },
+        "ml-model:requires-gpu": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ml-model:command",
+        "ml-model:input-volume",
+        "ml-model:output-volume"
+      ],
       "patternProperties": {
         "^(?!ml-model:)": {}
       },


### PR DESCRIPTION
This PR is a work in progress to add metadata describing how a user would run the model to generate inferences. 

For now, I've focused only on supporting Docker images for inferencing since it simplifies the problem a bit. The extension defines an additional Asset role (`ml-model:inferencing-image`) that can be used to refer to a Docker image to be used to run the model to generate inferences. Assets with this role are then extended with additional properties to describe how you would run a container based on this image to generate inferences. Some of these fields are loosely based on the [DLM Extension](https://github.com/sfoucher/dlm-extension) by @sfoucher. 

To Do:

- [ ] Add metadata to describe required format and shape of input data (similar to [Inputs Object](https://github.com/sfoucher/dlm-extension#inputs-object) in the DLM Extension).
- [ ] Add metadata to describe format and shape of output data (similar to [Outputs Object](https://github.com/sfoucher/dlm-extension#outputs-object) in DLM Extension).

Open Questions:

- Is an Asset the best way to represent a Docker image for this use-case? I considered using a Link, but did not see any examples of other STAC Extensions adding Link fields. Also, using Assets would allow us to use this in conjunction with other extensions like Versioning Indicators, File Info, etc. in the future.
- What should the recommended media type be for a Docker image? I took a wild guess based on OCI standards and used `application/vnd.oci.image.index.v1+json` in the example, but I'm not at all sure this is right.
- ~Is there a better way to construct the JSON schema so that it defines and requires certain fields only for assets with the `ml-model:inferencing-image` role?~ **UPDATE 2021-11-02:** This is no longer needed in the current iteration that uses a Compose file instead of a Docker image.

cc: @ymoisan @HamedAlemo